### PR TITLE
Fix SCSS rgb() function call for compatibility with newer Sass versions

### DIFF
--- a/app/assets/stylesheets/mapbox-gl-draw.scss
+++ b/app/assets/stylesheets/mapbox-gl-draw.scss
@@ -17,10 +17,10 @@
   height: 30px;
 
   &.active {
-    background-color: rgb(0 0 0 / 5%);
+    background-color: rgba(0, 0, 0, 0.05);
 
     &:hover {
-      background-color: rgb(0 0 0 / 5%);
+      background-color: rgba(0, 0, 0, 0.05);
     }
   }
 

--- a/app/assets/stylesheets/mapbox-gl.scss
+++ b/app/assets/stylesheets/mapbox-gl.scss
@@ -2,7 +2,7 @@
   font: 12px/20px Helvetica Neue,Arial,Helvetica,sans-serif;
   overflow: hidden;
   position: relative;
-  -webkit-tap-highlight-color: rgb(0 0 0 / 0);
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 .mapboxgl-canvas {

--- a/app/assets/stylesheets/mapbox-gl.scss
+++ b/app/assets/stylesheets/mapbox-gl.scss
@@ -229,7 +229,7 @@
 }
 
 .mapboxgl-ctrl button:not(:disabled):hover {
-  background-color: rgb(0 0 0 / 5%);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .mapboxgl-ctrl-group button:focus {
@@ -496,7 +496,7 @@ a.mapboxgl-ctrl-logo {
       }
 
       .mapboxgl-ctrl-attrib-button {
-        background-color: rgb(0 0 0 / 5%);
+        background-color: rgba(0, 0, 0, 0.05);
       }
     }
   }
@@ -668,7 +668,7 @@ a.mapboxgl-ctrl-logo {
   top: 0;
 
   &:hover {
-    background-color: rgb(0 0 0 / 5%);
+    background-color: rgba(0, 0, 0, 0.05);
   }
 }
 


### PR DESCRIPTION
This PR updates the rgb() call to the CSS color function format supported by newer Sass versions.